### PR TITLE
Conduit private key over IPC

### DIFF
--- a/android/app/src/main/aidl/ca/psiphon/conduit/state/IConduitStateService.aidl
+++ b/android/app/src/main/aidl/ca/psiphon/conduit/state/IConduitStateService.aidl
@@ -3,7 +3,10 @@ package ca.psiphon.conduit.state;
 import ca.psiphon.conduit.state.IConduitStateCallback;
 
 // Interface to register for conduit state updates
+// IMPORTANT: to keep the interface backwards compatible, new methods should be added to the end of the interface
 interface IConduitStateService {
     void registerClient(IConduitStateCallback callback);
     void unregisterClient(IConduitStateCallback callback);
+    // A simple method to fetch the Conduit private key
+    String fetchConduitPrivateKey();
 }

--- a/android/app/src/main/java/ca/psiphon/conduit/nativemodule/ConduitServiceParameters.java
+++ b/android/app/src/main/java/ca/psiphon/conduit/nativemodule/ConduitServiceParameters.java
@@ -89,7 +89,7 @@ public record ConduitServiceParameters(int maxClients, int limitUpstreamBytes, i
 
     // Store the object in SharedPreferences and return true if any values changed
     public boolean store(Context context) {
-        SharedPreferences preferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences preferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE | Context.MODE_MULTI_PROCESS);
         SharedPreferences.Editor editor = preferences.edit();
 
         boolean changed = false;
@@ -117,7 +117,7 @@ public record ConduitServiceParameters(int maxClients, int limitUpstreamBytes, i
         }
 
         if (changed) {
-            editor.apply();
+            editor.commit();
         }
 
         return changed;
@@ -127,7 +127,7 @@ public record ConduitServiceParameters(int maxClients, int limitUpstreamBytes, i
     public static ConduitServiceParameters load(Context context) {
         migrate(context); // Ensure preferences are up-to-date
 
-        SharedPreferences preferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences preferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE | Context.MODE_MULTI_PROCESS);
 
         int maxClients = preferences.getInt(MAX_CLIENTS_KEY, -1);
         int limitUpstreamBytes = preferences.getInt(LIMIT_UPSTREAM_BYTES_PER_SECOND_KEY, -1);

--- a/android/app/src/main/java/ca/psiphon/conduit/nativemodule/PackageHelper.java
+++ b/android/app/src/main/java/ca/psiphon/conduit/nativemodule/PackageHelper.java
@@ -38,10 +38,18 @@ public class PackageHelper {
     // Unmodifiable map of trusted packages with their corresponding sets of SHA-256 signature hashes
     private static final Map<String, Set<String>> TRUSTED_PACKAGES;
     static {
-        // Psiphon Pro package and its signatures as SHA-256 hashes using uppercase hex encoding, continuous (no separator)
         Map<String, Set<String>> map = new HashMap<>();
+        // Psiphon Pro package and its signatures as SHA-256 hashes using uppercase hex encoding, continuous (no separator)
         map.put("com.psiphon3.subscription", Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
                 "76DBEF15F67726D451A12359B8579C0D7A9F635D526AA37424DF131632F17810"
+                // Add additional valid signatures for the package as needed:
+                // "THEOTHERSIGNATUREHASHHERE"
+        ))));
+        // Ryve package and its signatures as SHA-256 hashes using uppercase hex encoding, continuous (no separator)
+        // app ID: network.ryve.app
+        // SHA256: AE:2E:20:B1:DC:53:72:C2:60:73:58:A3:BA:46:1E:1C:A4:30:6F:A1:74:FF:57:42:7A:1C:F5:2B:34:3F:AE:A0
+        map.put("network.ryve.app", Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+                "AE2E20B1DC5372C2607358A3BA461E1CA4306FA174FF57427A1CF52B343FAEA0"
                 // Add additional valid signatures for the package as needed:
                 // "THEOTHERSIGNATUREHASHHERE"
         ))));


### PR DESCRIPTION
Adds a simple method to fetch Conduit private key via IPC binding to ConduitStateService