### PR TITLE
Add service auto-restart after device reboot

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+  <!-- Required for receiving the 'system boot completed' broadcast in order to restart the Conduit service -->
+  <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
   <!-- Declare use of custom permission for 'service starting' broadcast verification -->
   <uses-permission android:name="ca.psiphon.conduit.nativemodule.SERVICE_STARTING_BROADCAST_PERMISSION" />
   <!-- Define custom permission for 'service starting' broadcast verification -->
@@ -59,11 +61,12 @@
         android:name=".nativemodule.logging.LoggingContentProvider"
         android:authorities="${applicationId}.log"
         android:exported="false"/>
-    <!-- Receiver for handling app updates -->
-    <receiver android:name=".nativemodule.ConduitUpdateReceiver"
+    <!-- Receiver for handling app updates and system reboot -->
+    <receiver android:name=".nativemodule.ConduitRestartReceiver"
         android:exported="false">
       <intent-filter>
         <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+        <action android:name="android.intent.action.BOOT_COMPLETED" />
       </intent-filter>
     </receiver>
     <!-- Service for reporting Conduit state to other apps -->

--- a/android/app/src/main/java/ca/psiphon/conduit/nativemodule/ConduitRestartReceiver.java
+++ b/android/app/src/main/java/ca/psiphon/conduit/nativemodule/ConduitRestartReceiver.java
@@ -25,21 +25,24 @@ import android.content.Intent;
 
 import ca.psiphon.conduit.nativemodule.logging.MyLog;
 
-public class ConduitUpdateReceiver extends BroadcastReceiver {
-    String TAG = ConduitUpdateReceiver.class.getSimpleName();
+public class ConduitRestartReceiver extends BroadcastReceiver {
+    String TAG = ConduitRestartReceiver.class.getSimpleName();
 
     @Override
     public void onReceive(Context context, Intent intent) {
         MyLog.init(context);
-        if (Intent.ACTION_MY_PACKAGE_REPLACED.equals(intent.getAction())) {
-            MyLog.i(TAG, "Conduit package was updated.");
+        String action = intent.getAction();
+        if (Intent.ACTION_MY_PACKAGE_REPLACED.equals(action) ||
+                Intent.ACTION_BOOT_COMPLETED.equals(action)
+        ) {
+            MyLog.i(TAG, "Received " + action + " intent, evaluating Conduit service restart.");
 
             if (Utils.getServiceRunningFlag(context)) {
-                MyLog.i(TAG, "Restarting Conduit service after update.");
+                MyLog.i(TAG, "Restarting Conduit service.");
                 try {
                     ConduitServiceInteractor.startInProxyWithLastKnownParams(context);
                 } catch (Exception e) {
-                    MyLog.e(TAG, "Failed to restart Conduit service after update: " + e.getMessage());
+                    MyLog.e(TAG, "Failed to restart Conduit service: " + e.getMessage());
                 }
             }
         }

--- a/android/app/src/main/java/ca/psiphon/conduit/nativemodule/ConduitServiceInteractor.java
+++ b/android/app/src/main/java/ca/psiphon/conduit/nativemodule/ConduitServiceInteractor.java
@@ -126,9 +126,11 @@ public class ConduitServiceInteractor {
         Intent intent = new Intent(context, ConduitService.class);
         intent.setAction(ConduitService.INTENT_ACTION_START_IN_PROXY_WITH_LAST_PARAMS);
         // Use startForegroundService instead of startService since:
-        // 1. When restarting after app upgrade from ConduitUpdateReceiver, we must use
-        //    startForegroundService to start from background, as Android allows this via
-        //    ACTION_MY_PACKAGE_REPLACED exemption.
+        // 1. When restarting after app upgrade or system reboot from ConduitRestartReceiver,
+        //    we must use startForegroundService to start from background, as Android allows this
+        //    via ACTION_MY_PACKAGE_REPLACED or ACTION_BOOT_COMPLETED exemptions, see:
+        //    https://developer.android.com/develop/background-work/services/fgs/restrictions-bg-start#background-start-restriction-exemptions
+        //
         // 2. The service will be foreground anyway - it's either already running as foreground
         //    or will promote itself to foreground shortly after starting.
         ContextCompat.startForegroundService(context, intent);


### PR DESCRIPTION
Extend existing app update handling to also restart the Conduit service after system reboot when it was previously running.
