### PR TITLE
Prepare for 1.6.1 release.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -119,8 +119,8 @@ android {
         applicationId 'ca.psiphon.conduit'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 46
-        versionName "1.6.1-RC.46"
+        versionCode 47
+        versionName "1.6.1"
     }
     signingConfigs {
         config {

--- a/src/components/ConduitSettings.tsx
+++ b/src/components/ConduitSettings.tsx
@@ -254,7 +254,7 @@ export function ConduitSettings() {
                                 originalValue={bytesToMB(
                                     inproxyParameters.limitUpstreamBytesPerSecond,
                                 )}
-                                min={8}
+                                min={1}
                                 max={INPROXY_MAX_MBPS_PER_PEER_MAX}
                                 style={[...lineItemStyle, ss.alignCenter]}
                                 onChange={updateInproxyLimitBytesPerSecond}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,8 +17,8 @@
  *
  */
 
-export const DEFAULT_INPROXY_MAX_CLIENTS = 4;
-export const DEFAULT_INPROXY_LIMIT_BYTES_PER_SECOND = 10 * 1000 * 1000; // 10 MB
+export const DEFAULT_INPROXY_MAX_CLIENTS = 2;
+export const DEFAULT_INPROXY_LIMIT_BYTES_PER_SECOND = 2 * 1000 * 1000; // 2 MB
 
 // if these are maxed out, it means a potential of 8Gbps at full capacity
 export const INPROXY_MAX_CLIENTS_MAX = 25;


### PR DESCRIPTION
Adjust default max clients and max bytes per second.
Adjust minimum max bytes per second.