### PR TITLE
docs(cli): add Docker Compose support and documentation

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -119,6 +119,19 @@ docker run -d --name conduit \
   conduit start --psiphon-config /config.json
 ```
 
+### Docker Compose
+
+Using Docker Compose is the easiest way to manage your Conduit node.
+
+1. Ensure you have a `psiphon_config.json` in the `cli/` directory.
+2. Start the node:
+
+```bash
+docker compose up -d
+```
+
+Your data will be persisted in a Docker volume named `conduit-data`.
+
 ## Data Directory
 
 Keys and state are stored in the data directory (default: `./data`):

--- a/cli/docker-compose.yml
+++ b/cli/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  conduit:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: conduit
+    restart: unless-stopped
+    volumes:
+      - conduit-data:/home/conduit/data
+      - ./psiphon_config.json:/etc/conduit/psiphon_config.json:ro
+    command: ["start", "--psiphon-config", "/etc/conduit/psiphon_config.json", "--data-dir", "/home/conduit/data"]
+
+volumes:
+  conduit-data:


### PR DESCRIPTION
## Description
This PR simplifies the deployment of the Conduit CLI node by adding Docker Compose support and updating the documentation.

## Changes
- Created `cli/docker-compose.yml`: Provides a standard configuration for running the Conduit node with persistent data volumes and external configuration mounting.
- Updated `cli/README.md`: Added a new "Docker Compose" section under the Docker category to provide clear, step-by-step instructions for users.

## How to test
1. Navigate to the `cli/` directory.
2. Ensure a valid `psiphon_config.json` exists in that directory (you can use `psiphon_config.example.json` as a template).
3. Run `docker compose up -d`.
4. Verify the container starts correctly and uses the mounted configuration.