### PR TITLE
Add Ryve QR code generation for CLI

### DIFF
--- a/cli/cmd/ryve.go
+++ b/cli/cmd/ryve.go
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026, Psiphon Inc.
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Psiphon-Inc/conduit/cli/internal/crypto"
+	"github.com/Psiphon-Inc/conduit/cli/internal/ryve"
+	"github.com/spf13/cobra"
+)
+
+var (
+	ryveName string
+)
+
+var ryveCmd = &cobra.Command{
+	Use:   "ryve",
+	Short: "Generate Ryve app QR code for claiming rewards",
+	Long: `Generate a QR code that can be scanned with the Ryve app to link your
+Conduit instance and claim rewards for relaying traffic.
+
+The QR code contains your Conduit's public key, allowing Ryve to attribute
+the traffic you relay to your account.`,
+	RunE: runRyve,
+}
+
+func init() {
+	rootCmd.AddCommand(ryveCmd)
+	ryveCmd.Flags().StringVarP(&ryveName, "name", "n", "", "custom name for your Conduit (shown in Ryve app)")
+}
+
+// persistedKey represents the key data saved to disk (matches config package)
+type persistedKey struct {
+	Mnemonic         string `json:"mnemonic"`
+	PrivateKeyBase64 string `json:"privateKeyBase64"`
+}
+
+func runRyve(cmd *cobra.Command, args []string) error {
+	keyPath := filepath.Join(GetDataDir(), "conduit_key.json")
+
+	// Check if key file exists
+	data, err := os.ReadFile(keyPath)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("no key found at %s\nRun 'conduit start' first to generate keys", keyPath)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read key file: %w", err)
+	}
+
+	// Parse the key file
+	var pk persistedKey
+	if err := json.Unmarshal(data, &pk); err != nil {
+		return fmt.Errorf("failed to parse key file: %w", err)
+	}
+
+	if pk.PrivateKeyBase64 == "" {
+		return fmt.Errorf("key file is missing privateKeyBase64")
+	}
+
+	// Decode and validate the key
+	privateKeyBytes, err := base64.RawStdEncoding.DecodeString(pk.PrivateKeyBase64)
+	if err != nil {
+		// Try standard encoding as fallback
+		privateKeyBytes, err = base64.StdEncoding.DecodeString(pk.PrivateKeyBase64)
+		if err != nil {
+			return fmt.Errorf("failed to decode private key: %w", err)
+		}
+	}
+
+	// Validate it's a proper Ed25519 key
+	_, err = crypto.ParsePrivateKey(privateKeyBytes)
+	if err != nil {
+		return fmt.Errorf("invalid key: %w", err)
+	}
+
+	// Generate the deep link
+	// Use RawStdEncoding (base64 without padding) to get the 86-char format
+	keyBase64 := base64.RawStdEncoding.EncodeToString(privateKeyBytes)
+
+	deepLink, err := ryve.GenerateDeepLink(keyBase64, ryveName)
+	if err != nil {
+		return fmt.Errorf("failed to generate deep link: %w", err)
+	}
+
+	// Print QR code and URL
+	fmt.Println()
+	fmt.Println("Scan this QR code with the Ryve app to claim rewards:")
+	fmt.Println()
+	ryve.PrintQRAndURL(os.Stdout, deepLink)
+
+	return nil
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/tyler-smith/go-bip39 v1.1.0
 	golang.org/x/crypto v0.39.0
+	rsc.io/qr v0.2.0
 )
 
 require (

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -408,5 +408,7 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+rsc.io/qr v0.2.0 h1:6vBLea5/NRMVTz8V66gipeLycZMl/+UlFmk8DvqQ6WY=
+rsc.io/qr v0.2.0/go.mod h1:IF+uZjkb9fqyeF/4tlBoynqmQxUoPfWEKh921coOuXs=
 tailscale.com v1.58.2 h1:5trkhh/fpUn7f6TUcGUQYJ0GokdNNfNrjh9ONJhoc5A=
 tailscale.com v1.58.2/go.mod h1:faWR8XaXemnSKCDjHC7SAQzaagkUjA5x4jlLWiwxtuk=

--- a/cli/internal/ryve/ryve.go
+++ b/cli/internal/ryve/ryve.go
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026, Psiphon Inc.
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package ryve provides utilities for generating Ryve app deep links and QR codes
+package ryve
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"rsc.io/qr"
+)
+
+// DeepLinkPrefix is the Ryve app deep link scheme for claiming conduits
+const DeepLinkPrefix = "network.ryve.app://(app)/conduits?claim="
+
+// ScanData represents the data structure for Ryve QR codes
+type ScanData struct {
+	Version int      `json:"version"`
+	Data    DataBody `json:"data"`
+}
+
+// DataBody contains the key and optional name for the conduit
+type DataBody struct {
+	Key  string `json:"key"`
+	Name string `json:"name,omitempty"`
+}
+
+// GenerateDeepLink creates a Ryve deep link URL from a base64-encoded keypair
+// The key should be 86 characters (64 bytes encoded as base64 without padding)
+func GenerateDeepLink(keyBase64 string, name string) (string, error) {
+	if len(keyBase64) != 86 {
+		return "", fmt.Errorf("invalid key length: expected 86 characters, got %d", len(keyBase64))
+	}
+
+	data := ScanData{
+		Version: 1,
+		Data: DataBody{
+			Key:  keyBase64,
+			Name: name,
+		},
+	}
+
+	// Marshal to JSON
+	jsonBytes, err := json.Marshal(data)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal data: %w", err)
+	}
+
+	// Encode as base64url (URL-safe base64 with padding)
+	encoded := base64.URLEncoding.EncodeToString(jsonBytes)
+
+	return DeepLinkPrefix + encoded, nil
+}
+
+// PrintQR prints a compact ASCII QR code using Unicode half-block characters.
+// This produces a QR code that is half the height of traditional ASCII QR codes.
+func PrintQR(w io.Writer, data string) error {
+	code, err := qr.Encode(data, qr.L)
+	if err != nil {
+		return fmt.Errorf("failed to encode QR: %w", err)
+	}
+
+	size := code.Size
+	var sb strings.Builder
+
+	// Using Unicode half-block characters to pack 2 rows into 1:
+	// ▀ (U+2580) = top half block  (top=black, bottom=white)
+	// ▄ (U+2584) = bottom half block (top=white, bottom=black)
+	// █ (U+2588) = full block (both black)
+	// " " space = both white
+
+	// Add quiet zone (1 row = 2 QR rows worth of white)
+	quietRow := strings.Repeat("█", size+2)
+	sb.WriteString(quietRow + "\n")
+
+	// Process 2 rows at a time
+	for y := 0; y < size; y += 2 {
+		sb.WriteString("█") // left quiet zone
+
+		for x := 0; x < size; x++ {
+			topBlack := code.Black(x, y)
+			bottomBlack := false
+			if y+1 < size {
+				bottomBlack = code.Black(x, y+1)
+			}
+
+			// QR black = we want dark, QR white = we want light
+			// Terminal: █ is filled, space is empty
+			// We invert: QR black -> space (dark on light background looks better inverted)
+			switch {
+			case !topBlack && !bottomBlack:
+				sb.WriteString("█") // both white -> full block
+			case !topBlack && bottomBlack:
+				sb.WriteString("▀") // top white, bottom black -> upper half
+			case topBlack && !bottomBlack:
+				sb.WriteString("▄") // top black, bottom white -> lower half
+			case topBlack && bottomBlack:
+				sb.WriteString(" ") // both black -> space
+			}
+		}
+
+		sb.WriteString("█\n") // right quiet zone
+	}
+
+	// Bottom quiet zone
+	sb.WriteString(quietRow + "\n")
+
+	_, err = fmt.Fprint(w, sb.String())
+	return err
+}
+
+// PrintQRAndURL prints the QR code followed by the URL to the given writer
+func PrintQRAndURL(w io.Writer, deepLink string) error {
+	if err := PrintQR(w, deepLink); err != nil {
+		return err
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Ryve Deep Link:")
+	fmt.Fprintln(w, deepLink)
+	return nil
+}


### PR DESCRIPTION
  Adds the ability to generate Ryve app QR codes from the CLI, matching the functionality in the mobile/desktop apps.

  # Changes

  - New conduit ryve command to generate and display QR code
  - New --show-ryve-qr flag on conduit start to display QR before starting
  - New --name flag to set custom Conduit name (shown in Ryve app)
  - Uses compact Unicode half-block characters for smaller terminal QR output

  # Usage

  ## Standalone command
  conduit ryve
  conduit ryve --name "My Server"

  ## With start command
  conduit start --show-ryve-qr --psiphon-config
  config.json

  # Files

  - cmd/ryve.go - New ryve command
  - internal/ryve/ryve.go - QR generation utilities (shared with start command)
  - cmd/start.go - Added --show-ryve-qr and --name flags
  - go.mod / go.sum - Added rsc.io/qr dependency