### PR TITLE
build: use CGO_ENABLED=0 for fully static binaries

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -31,7 +31,7 @@ define GO_BUILD
 	ALL_TAGS="$(BASE_TAGS)" && \
 	if [ -n "$(2)" ]; then ALL_TAGS="$$ALL_TAGS,$(2)"; fi && \
 	echo "Building $(3)/$(4) -> $(1) with tags: $$ALL_TAGS" && \
-	GOOS=$(3) GOARCH=$(4) $(GO) build \
+	CGO_ENABLED=0 GOOS=$(3) GOARCH=$(4) $(GO) build \
 	  -tags "$$ALL_TAGS" \
 	  -ldflags "\
 	    -s -w \


### PR DESCRIPTION
Build with `CGO_ENABLED=0` to produce fully static binaries that don't depend on system libc.

This improves portability and eliminates "GLIBC_X.XX not found" errors when running on systems with older glibc versions or minimal Docker images.