### PR TITLE
Add linux/386 build target for iSH on iOS

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -111,10 +111,12 @@ jobs:
                       cli/dist/conduit-linux-arm64
                       cli/dist/conduit-linux-armv7
                       cli/dist/conduit-linux-armv6
+                      cli/dist/conduit-linux-386
                       cli/dist/conduit-monitor-linux-amd64
                       cli/dist/conduit-monitor-linux-arm64
                       cli/dist/conduit-monitor-linux-armv7
                       cli/dist/conduit-monitor-linux-armv6
+                      cli/dist/conduit-monitor-linux-386
                       cli/dist/checksums.txt
 
             - name: Create Release
@@ -130,6 +132,7 @@ jobs:
                       cli/dist/conduit-linux-arm64
                       cli/dist/conduit-linux-armv7
                       cli/dist/conduit-linux-armv6
+                      cli/dist/conduit-linux-386
                       cli/dist/conduit-darwin-amd64
                       cli/dist/conduit-darwin-arm64
                       cli/dist/conduit-windows-amd64.exe

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -24,6 +24,7 @@ PSIPHON_REPO := https://github.com/Psiphon-Labs/psiphon-tunnel-core.git
 # $(3) = GOOS
 # $(4) = GOARCH
 # $(5) = GOARM (optional)
+# $(6) = extra env vars (optional, e.g. GO386=softfloat)
 define GO_BUILD
 	@BUILDDATE=$$(date +%Y-%m-%dT%H:%M:%S%z) && \
 	BUILDREPO=$$(cd psiphon-tunnel-core && git config --get remote.origin.url) && \
@@ -32,7 +33,7 @@ define GO_BUILD
 	ALL_TAGS="$(BASE_TAGS)" && \
 	if [ -n "$(2)" ]; then ALL_TAGS="$$ALL_TAGS,$(2)"; fi && \
 	echo "Building $(3)/$(4) -> $(1) with tags: $$ALL_TAGS" && \
-	CGO_ENABLED=0 GOOS=$(3) GOARCH=$(4) $(if $(5),GOARM=$(5)) $(GO) build \
+	CGO_ENABLED=0 GOOS=$(3) GOARCH=$(4) $(if $(5),GOARM=$(5)) $(if $(6),$(6)) $(GO) build \
 	  -tags "$$ALL_TAGS" \
 	  -ldflags "\
 	    -s -w \
@@ -50,9 +51,10 @@ endef
 # $(2) = GOOS
 # $(3) = GOARCH
 # $(4) = GOARM (optional)
+# $(5) = extra env vars (optional, e.g. GO386=softfloat)
 define GO_BUILD_MONITOR
 	@echo "Building monitor $(2)/$(3) -> $(1)"
-	@CGO_ENABLED=0 GOOS=$(2) GOARCH=$(3) $(if $(4),GOARM=$(4)) $(GO) build \
+	@CGO_ENABLED=0 GOOS=$(2) GOARCH=$(3) $(if $(4),GOARM=$(4)) $(if $(5),$(5)) $(GO) build \
 	  -ldflags "-s -w" \
 	  -o $(1) ./scripts/monitor
 endef
@@ -133,6 +135,10 @@ build-linux-armv6: check-go check-setup
 	$(call GO_BUILD,dist/conduit-linux-armv6,,linux,arm,6)
 	$(call GO_BUILD_MONITOR,dist/conduit-monitor-linux-armv6,linux,arm,6)
 
+build-linux-386: check-go check-setup
+	$(call GO_BUILD,dist/conduit-linux-386,,linux,386,,GO386=softfloat)
+	$(call GO_BUILD_MONITOR,dist/conduit-monitor-linux-386,linux,386,,GO386=softfloat)
+
 build-darwin: check-go check-setup
 	$(call GO_BUILD,dist/conduit-darwin-amd64,,darwin,amd64)
 	$(call GO_BUILD_MONITOR,dist/conduit-monitor-darwin-amd64,darwin,amd64)
@@ -150,7 +156,7 @@ build-freebsd: check-go check-setup
 	$(call GO_BUILD_MONITOR,dist/conduit-monitor-freebsd-amd64,freebsd,amd64)
 
 # Build for all platforms
-build-all: check-go check-setup build-linux build-linux-arm build-linux-armv7 build-linux-armv6 build-darwin build-darwin-arm build-windows build-freebsd
+build-all: check-go check-setup build-linux build-linux-arm build-linux-armv7 build-linux-armv6 build-linux-386 build-darwin build-darwin-arm build-windows build-freebsd
 
 # Build for all platforms with embedded config
 build-all-embedded: check-go check-setup check-psiphon-config
@@ -160,6 +166,7 @@ build-all-embedded: check-go check-setup check-psiphon-config
 	$(call GO_BUILD,dist/conduit-linux-arm64,$(EMBED_TAG),linux,arm64)
 	$(call GO_BUILD,dist/conduit-linux-armv7,$(EMBED_TAG),linux,arm,7)
 	$(call GO_BUILD,dist/conduit-linux-armv6,$(EMBED_TAG),linux,arm,6)
+	$(call GO_BUILD,dist/conduit-linux-386,$(EMBED_TAG),linux,386,,GO386=softfloat)
 	$(call GO_BUILD,dist/conduit-darwin-amd64,$(EMBED_TAG),darwin,amd64)
 	$(call GO_BUILD,dist/conduit-darwin-arm64,$(EMBED_TAG),darwin,arm64)
 	$(call GO_BUILD,dist/conduit-windows-amd64.exe,$(EMBED_TAG),windows,amd64)
@@ -170,6 +177,7 @@ build-all-embedded: check-go check-setup check-psiphon-config
 	$(call GO_BUILD_MONITOR,dist/conduit-monitor-linux-arm64,linux,arm64)
 	$(call GO_BUILD_MONITOR,dist/conduit-monitor-linux-armv7,linux,arm,7)
 	$(call GO_BUILD_MONITOR,dist/conduit-monitor-linux-armv6,linux,arm,6)
+	$(call GO_BUILD_MONITOR,dist/conduit-monitor-linux-386,linux,386,,GO386=softfloat)
 	$(call GO_BUILD_MONITOR,dist/conduit-monitor-darwin-amd64,darwin,amd64)
 	$(call GO_BUILD_MONITOR,dist/conduit-monitor-darwin-arm64,darwin,arm64)
 	$(call GO_BUILD_MONITOR,dist/conduit-monitor-windows-amd64.exe,windows,amd64)


### PR DESCRIPTION
Adds a statically linked x86 32-bit Linux binary (conduit-linux-386) so volunteers can run a Conduit node via iSH on iOS devices. Built with GO386=softfloat to avoid SSE2 emulation overhead in iSH's x86 interpreter.